### PR TITLE
MODS TILE move scripts

### DIFF
--- a/cfgmk.py
+++ b/cfgmk.py
@@ -1,0 +1,93 @@
+
+'''
+Idea is to source the IOC template from the location where the 
+present IOC is and modify parameters based on new location code.
+Second step would be to combine with group change to do this iteratively.
+Run this where you want new cfg to be stored, for sake of simplicity
+
+'''
+import os
+from os import path
+import shutil
+import argparse 
+import sys
+import re
+import subprocess
+import json
+import pandas as pd
+
+from happi import Client
+from happi.errors import DuplicateError
+#from tile_move import GroupChange
+'''
+class Config_gen:
+    def __init__():
+'''
+# open the file and if the field to be updated exists, record its value and update it
+def update_cfg(cfg_path, device_name, loc_code):
+    #try:
+        with open(cfg_path, 'r') as file:
+            cfg=file.read
+        
+        client= Client(path='/reg/g/pcds/epics-dev/nagar123/mods/db.json')
+        device=client.search(name=device_name)
+        for d in device:
+            print(d)
+        old_code=d.item.location_group.split('_')[1]# to substitute all instances of old loc with new loc_code
+        # create a directory for storing new cfg file in the current working directory
+        dir_name="test_cfg"
+        current_dir=os.getcwd()
+        dir_path = os.path.join(current_dir, dir_name)
+        os.makedirs(dir_path, exist_ok=True)
+
+        source_cfg=os.path.basename(cfg_path)
+        dest_cfg=os.path.join(dir_path, source_cfg)
+        #created a copy of the cfg file in current dir/test_cfg
+        shutil.copy2(source_cfg, dest_cfg)
+        
+        with open(dest_cfg, 'r') as file:
+            mod_cfg= file.read()
+
+
+
+
+        #ioc_release, ioc_serial, ioc_model, ioc_arch, ioc_channel do not change
+        #ioc_alias, ioc_base, ioc_name associated fields in cfg change
+        #clean_cfg= clean_ansi(mod_cfg)
+            
+        #generate a pattern 
+        pattern = re.compile(re.escape(old_code), re.IGNORECASE)
+        #print(pattern)
+        mod_cfg= pattern.sub(lambda match: loc_code.upper() if match.group().isupper() else loc_code.lower(), mod_cfg)
+        with open(dest_cfg, 'w') as file:
+            file.write(mod_cfg)
+    #except OSError:
+       #  print("Input valid path to cfg file")
+
+
+        
+        
+#def main(device_name,cfg_path,loc_code):
+     #update_cfg(cfg_path, device_name, loc_code)
+     #update_cfg('/reg/g/pcds/epics-dev/nagar123/mods/mods_tile_move/tile-move', 'lm2k2_inj_dp1_tf1_sl1', 'lm9k9')
+def main():   
+    device_name = "lm2k2_inj_dp1_tf1_sl1"
+    cfg_path = "/reg/g/pcds/epics-dev/nagar123/mods/mods_tile_move/tile-move/ioc-test-file.cfg"
+    loc_code = "lm9k9"
+    update_cfg(cfg_path,device_name,loc_code)
+     
+if __name__ == "__main__":
+        #conda_activate_cmd="source pcds_conda"
+        #subprocess.run(conda_activate_cmd, shell=True, executable="/bin/sh")
+        #argumments for argparse can be improved
+        main()
+        '''
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--n", help="name of device to be shifted")
+        parser.add_argument("--cfg", help="absolute path to ioc cfg file")
+        parser.add_argument("--f", help="final destination location code for the devices after shifting")
+        args = parser.parse_args()
+        device_name = args.n
+        cfg_path = args.cfg
+        loc_code=args.f
+        '''

--- a/tile_move.py
+++ b/tile_move.py
@@ -1,27 +1,47 @@
 
 import argparse
-
+import json
+import re
 from happi import Client
 from happi.errors import DuplicateError
-from validate import validate
+#from validate import validate
 import pandas as pd
 
 
 class GroupChange:
     def __init__(self, db_path):
         self.client=Client(path='/reg/g/pcds/epics-dev/nagar123/mods/db.json')
-        self.validator =validate()
+       # self.validator =validate()
 
     #do we want a confirmation prompt for each entry or once for all in the location_group?
     def display_changes(self, entry):
             entry.item.show_info()
-            
+    
+    def all_chars_caps_ignore_special(self, string):
+        """
+        Check if all alphabetic characters in the string are uppercase, ignoring special characters.
+        """
+        # Iterate through each character in the string
+        for char in string:
+            # Check if the character is an alphabetic character
+            if char.isalpha():
+                # Check if the alphabetic character is not uppercase
+                if not char.isupper():
+                    return False  # Return False if any alphabetic character is not uppercase
+        return True
+                
     def location_group_change(self, loc_grp, new_name):
-        loc_code = loc_grp.split('_')[1]
+        dict_beamline={'LM2K2':'CRIX_MODS','LM1K4':'IP1_MODS','LM1K2':'QRIX_MODS'}
         
+        test_arr={'ioc_alias', 'ioc_base','prefix','ioc_name','location_group','name','beamline', 'ioc_location'}
+        json_file_path = "/reg/g/pcds/epics-dev/nagar123/mods/db.json"
+
+        loc_code = loc_grp.split('_')[1]
         entries_to_modify = self.client.search(location_group=loc_grp)
         print(f"Number of entries that will be modified are {len(entries_to_modify)}")
-        
+        # Read the JSON file
+        with open(json_file_path, "r") as file:
+          data = json.load(file)
 
         if not entries_to_modify:
             print("No entries found for the search criteria.")
@@ -33,81 +53,39 @@ class GroupChange:
                 globalFlag=1
 
             for entry in entries_to_modify:
-                inital_values={}
+                initial_values={}
                 final_values={}
-                #some device may miss fields hence the use of if statements below
-                try:
-                        if 'ioc_alias' in entry: 
-                            old_ioc_alias=entry.item.ioc_alias
-                            inital_values['ioc_alias']=old_ioc_alias
-                            new_ioc_alias=old_ioc_alias.replace(loc_code.upper(), new_name.upper())
-                            entry.item.ioc_alias=new_ioc_alias
-                            final_values['ioc_alias']=entry.item.ioc_alias
-                        if 'ioc_base' in entry: 
-                            old_ioc_base=entry.item.ioc_base
-                            inital_values['ioc_base']=old_ioc_base
-                            new_ioc_base=old_ioc_base.replace(loc_code.upper(), new_name.upper())
-                            entry.item.ioc_base=new_ioc_base
-                            final_values['ioc_base']=entry.item.ioc_base
-                        if 'prefix' in entry: 
-                            old_prefix=entry.item.prefix
-                            inital_values['prefix']=old_prefix
-                            new_prefix=old_prefix.replace(loc_code.upper(), new_name.upper())
-                            entry.item.prefix=new_prefix
-                            final_values['prefix']=entry.item.prefix
-                        if 'ioc_name' in entry: 
-                            old_ioc_name=entry.item.ioc_name
-                            inital_values['ioc_name']=old_ioc_name
-                            new_ioc_name=old_ioc_name.replace(loc_code.lower(), new_name.lower())
-                            entry.item.ioc_name=new_ioc_name
-                            final_values['ioc_name']=entry.item.ioc_name
-                        if 'location_group' in entry: 
-                            old_location_grp=entry.item.location_group
-                            inital_values['location_group']=old_location_grp
-                            new_loc_grp=old_location_grp.replace(loc_code.lower(), new_name.lower())
-                            entry.item.location_group=new_loc_grp
-                            final_values['location_group']=entry.item.location_group
-                        if 'name' in entry: 
-                            old_name=entry.item.name
-                            inital_values['name']=old_name
-                            final_name=old_name.replace(loc_code.lower(), new_name.lower())
-                            entry.item.name=final_name
-                            final_values['name']=entry.item.name
-                        
-                        df_initial=pd.DataFrame.from_dict(inital_values, orient='index', columns=['Old Value'])
-                        df_initial.index.name='Device parameter'
-
-                        df_final=pd.DataFrame.from_dict(final_values, orient='index', columns=['New Value'])
-                        df_final.index.name='Device parameter'
-
-                        df_compare=pd.concat([df_initial, df_final], axis=1)
-                        print(df_compare)
-                        #changes are displayed in a dataframe for easy comparision with previous values
-                        if globalFlag == 1:
-                            entry.item.save()
-                            continue
-                        if  globalFlag == 0:
-                            confirmation = input("Confirm changes (y/N): ").strip().lower()
-                            
-                            if confirmation == 'y':
-                                entry.item.save()
-                                print(f"Location successfully changed for {entry.item.name}")
-                                #entry.item.show_info()
-                            else:
-                                if 'ioc_alias' in entry: entry.item.ioc_alias=old_ioc_alias
-                                if 'ioc_base' in entry: entry.item.ioc_base=old_ioc_base
-                                if 'prefix' in entry: entry.item.prefix=old_prefix
-                                if 'ioc_name' in entry: entry.item.ioc_name=old_ioc_name
-                                if 'location_group' in entry: entry.item.location_group=old_location_grp
-                                if 'name' in entry: entry.item.name=old_name
-                                entry.item.save()
-                                print(f"No changes made to device entry {entry.item.name}")
-                        new_ioc_alias=new_ioc_base=new_ioc_name=new_loc_grp=final_name=new_prefix=''
-                        old_ioc_alias=old_ioc_base=old_ioc_name=old_location_grp=old_name=old_prefix=''
-
-                except DuplicateError as e:
-                    print(f"An entry with the same name already exists: {e}")
                 
+                #try:
+                for test_item in test_arr:
+                                if test_item in entry:
+                                    if(self.all_chars_caps_ignore_special(str(entry[test_item]))):
+                                        initial_values[str(test_item)]= entry[test_item]
+                                        print("if meta", entry.metadata['name'])
+                                        entry.metadata[test_item]=str(entry.item.get(test_item)).replace(loc_code.upper(), new_name.upper())
+                                        entry.item.save()
+                                        final_values[str(test_item)]= entry[test_item]
+                                    else:
+                                        initial_values[str(test_item)]= entry[test_item]
+                                        #print("before" ,entry)
+                                        entry.metadata[test_item]=str(entry.item.get(test_item)).replace(loc_code.lower(), new_name.lower())
+                                        #print("after ", entry, "\n")
+                                        entry.item.save()                                        
+                                        final_values[str(test_item)]= entry.metadata[test_item]
+                                
+                                if test_item == 'beamline':
+                                    initial_values[str(test_item)]= entry[test_item]
+                                    entry.metadata[test_item]=dict_beamline[new_name.upper()]    
+                                    entry.item.save()
+                                    final_values[str(test_item)]= entry[test_item]
+                df_initial=pd.DataFrame.from_dict(initial_values, orient='index', columns=['Old Value'])
+                df_initial.index.name='Device parameter'
+
+                df_final=pd.DataFrame.from_dict(final_values, orient='index', columns=['New Value'])
+                df_final.index.name='Device parameter'
+
+                df_compare=pd.concat([df_initial, df_final], axis=1)
+                print(df_compare)
     def main(self, loc_grp, new_name):
         if not loc_grp or not new_name:
                 print("Please provide both location group (--loc_grp) and new name (--new_name)")


### PR DESCRIPTION
Addition for tile_move script helpful in auto changing location for MODS. Request review.

The script works by providing two inputs, i.e. the origin location group and the destination location code. 
A help message is displayed automatically. Ensure the final destination code is amongst LM1K2, LM2K2, LM1K4.

Detailed confluence page: 
[https://confluence.slac.stanford.edu/display/L2SI/MODS+Move+Script+-+Intern+Project](https://confluence.slac.stanford.edu/display/L2SI/MODS+Move+Script+-+Intern+Project)
